### PR TITLE
Maya: RenderSettings class easy access to its project settings

### DIFF
--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -15,6 +15,12 @@ from openpype.hosts.maya.api.commands import reset_frame_range
 
 
 class RenderSettings(object):
+    """Render Settings defined in OpenPype project settings per renderer.
+
+    Based on the Project Settings this allows you to query and set the render
+    setting defaults for the current project.
+
+    """
 
     _image_prefix_nodes = {
         'vray': 'vraySettings.fileNamePrefix',

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -286,8 +286,12 @@ class RenderSettings(object):
             raise TypeError("Item must be string type")
 
         setting = self._project_settings["maya"]["RenderSettings"]
-        for path in item.split("/"):
-            setting = setting[path]
+        try:
+            for path in item.split("/"):
+                setting = setting[path]
+        except KeyError:
+            settings_path = "project_settings/maya/RenderSettings/" + item
+            raise KeyError(settings_path)
 
         return setting
 

--- a/openpype/hosts/maya/api/lib_rendersettings.py
+++ b/openpype/hosts/maya/api/lib_rendersettings.py
@@ -20,6 +20,17 @@ class RenderSettings(object):
     Based on the Project Settings this allows you to query and set the render
     setting defaults for the current project.
 
+    The RenderSettings can query the `project_settings/maya/RenderSettings`
+    entries by accessing its items. It also allows to get a setting values
+    nested down using a forward slash `/` in the item. For example:
+        >>> settings = RenderSettings()
+        >>> # project_settings/maya/RenderSettings/aov_separator
+        >>> settings["aov_separator"]
+        >>> # project_settings/maya/RenderSettings/arnold_renderer/image_format
+        >>> settings["arnold_renderer/image_format"]
+        >>> # or with a default value fallback if setting does not exist
+        >>> settings.get("arnold_renderer/image_format", default=True)
+
     """
 
     _image_prefix_nodes = {
@@ -44,15 +55,8 @@ class RenderSettings(object):
 
     def get_aov_separator(self):
         # project_settings/maya/RenderSettings/aov_separator
-        try:
-            aov_separator = self._aov_chars[(
-                self._project_settings["maya"]
-                ["RenderSettings"]
-                ["aov_separator"]
-            )]
-        except KeyError:
-            aov_separator = "_"
-        return aov_separator
+        aov_separator_name = self["aov_separator"]
+        return self._aov_chars.get(aov_separator_name, "_")
 
     @classmethod
     def get_image_prefix_attr(cls, renderer):
@@ -94,14 +98,13 @@ class RenderSettings(object):
             prefix = hardcoded_prefixes[renderer]
             return _format_prefix(prefix)
 
-        render_settings = self._project_settings["maya"]["RenderSettings"]
         renderer_key = "{}_renderer".format(renderer)
-        if renderer_key not in render_settings:
+        if renderer_key not in self:
             print("Renderer {} has no render "
                   "settings implementation.".format(renderer))
             return
 
-        renderer_settings = render_settings[renderer_key]
+        renderer_settings = self[renderer_key]
         renderer_image_prefix = renderer_settings.get("image_prefix")
         if renderer_image_prefix is None:
             print("Renderer {} has no image prefix setting.".format(renderer))
@@ -133,8 +136,7 @@ class RenderSettings(object):
         self._set_global_output_settings()
 
         # Reset current frame
-        reset_frame = self._project_settings["maya"]["RenderSettings"]["reset_current_frame"] # noqa
-        if reset_frame:
+        if self["reset_current_frame"]:
             start_frame = cmds.getAttr("defaultRenderGlobals.startFrame")
             cmds.currentTime(start_frame, edit=True)
 
@@ -150,7 +152,7 @@ class RenderSettings(object):
         from mtoa.core import createOptions  # noqa
         from mtoa.aovs import AOVInterface  # noqa
         createOptions()
-        arnold_render_presets = self._project_settings["maya"]["RenderSettings"]["arnold_renderer"] # noqa
+        arnold_render_presets = self["arnold_renderer"]
         # Force resetting settings and AOV list to avoid having to deal with
         # AOV checking logic, for now.
         # This is a work around because the standard
@@ -194,12 +196,7 @@ class RenderSettings(object):
 
     def _set_redshift_settings(self, width, height):
         """Sets settings for Redshift."""
-        redshift_render_presets = (
-            self._project_settings
-            ["maya"]
-            ["RenderSettings"]
-            ["redshift_renderer"]
-        )
+        redshift_render_presets = self["redshift_renderer"]
         ext = redshift_render_presets["image_format"]
 
         # Set image format
@@ -215,12 +212,7 @@ class RenderSettings(object):
         """Sets important settings for Vray."""
         settings = cmds.ls(type="VRaySettingsNode")
         node = settings[0] if settings else cmds.createNode("VRaySettingsNode")
-        vray_render_presets = (
-            self._project_settings
-            ["maya"]
-            ["RenderSettings"]
-            ["vray_renderer"]
-        )
+        vray_render_presets = self["vray_renderer"]
         # Set aov separator
         # First we need to explicitly set the UI items in Render Settings
         # because that is also what V-Ray updates to when that Render Settings
@@ -282,3 +274,26 @@ class RenderSettings(object):
                 cmds.setAttr(str(attribute), int(value)) # noqa
             elif (cmds.getAttr(str(attribute), type=True)) == "string":
                 cmds.setAttr(str(attribute), str(value), type = "string") # noqa
+
+    def get(self, item, default=None):
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
+    def __getitem__(self, item):
+        if not isinstance(item, six.string_types):
+            raise TypeError("Item must be string type")
+
+        setting = self._project_settings["maya"]["RenderSettings"]
+        for path in item.split("/"):
+            setting = setting[path]
+
+        return setting
+
+    def __contains__(self, item):
+        try:
+            self[item]
+        except KeyError:
+            return False
+        return True


### PR DESCRIPTION
## Brief description

Allow more readable access to `project_settings/maya/RenderSettings` setting entries in the `RenderSettings` class.

## Description

This implements `get()`, `__getitem__`, `__contains__` on the Render Settings class.

## Additional info

Examples:

```python
render_settings = RenderSettings()

# project_settings/maya/RenderSettings/aov_separator
render_settings["aov_separator"]

# project_settings/maya/RenderSettings/arnold_renderer/image_format
render_settings["arnold_renderer/image_format"]

# project_settings/maya/RenderSettings/arnold_renderer/image_format
# with a default value fallback if setting does not exist
render_settings.get("arnold_renderer/image_format", default=True)

# Check if setting exists
"aov_separator" in render_settings
"arnold_renderer/image_format" in render_settings
```