### PR TITLE
Change family attribute to use.

### DIFF
--- a/openpype/settings/defaults/project_settings/global.json
+++ b/openpype/settings/defaults/project_settings/global.json
@@ -251,7 +251,7 @@
                     }
                 },
                 {
-                    "families": [],
+                    "families": ["review"],
                     "hosts": [
                         "maya"
                     ],
@@ -259,7 +259,7 @@
                     "task_names": [],
                     "subsets": [],
                     "burnins": {
-                        "maya_burnin": {
+                        "maya_review_burnin": {
                             "TOP_LEFT": "{yy}-{mm}-{dd}",
                             "TOP_CENTERED": "{focalLength:.2f} mm",
                             "TOP_RIGHT": "{anatomy[version]}",
@@ -267,9 +267,7 @@
                             "BOTTOM_CENTERED": "{asset}",
                             "BOTTOM_RIGHT": "{frame_start}-{current_frame}-{frame_end}",
                             "filter": {
-                                "families": [
-                                    "review"
-                                ],
+                                "families": [],
                                 "tags": []
                             }
                         }


### PR DESCRIPTION
This is for #4791.

Looks like we need to use a diffferent family attribute. Dont know why there are 2.
Also change the profile name to reflect its exclusivity to `review` family.

Tested in Maya 2023 successfully.