### PR TITLE
Camera path filter, project:rootDirectory callback and case-fix

### DIFF
--- a/openpype/hosts/gaffer/api/lib.py
+++ b/openpype/hosts/gaffer/api/lib.py
@@ -79,3 +79,40 @@ def arrange(nodes: List[Gaffer.Node], parent: Optional[Gaffer.Node] = None):
 
     graph = GafferUI.GraphGadget(parent)
     graph.getLayout().layoutNodes(graph, Gaffer.StandardSet(nodes))
+
+
+def find_camera_paths(out_plug, starting_path="/"):
+    """Traverses the scene starting at `starting_path` collecting a list of paths
+    to all the Camera objects it finds
+
+    Args:
+        out_plug (GafferScene.ScenePlug): Typically the `["out]` plug of a node to traverse
+            the scene hierarchy from.
+        starting_path (string): The path to the starting point of the traversal.
+
+    Returns:
+        list: List of found paths to cameras.
+
+    """
+    cameras = []
+    find_paths(out_plug, starting_path, "Camera", cameras)
+    return cameras
+
+
+def find_paths(scene, path, object_type_name, found_paths_list):
+    """The actual scene traversal function. Populates the passed `found_paths_list` wit found paths.
+
+    Args:
+        scene (GafferScene.ScenePlug): The plug whose scene we will traverse.
+        path (string): Starting path of traversal.
+        object_type_name (String): The name of the objec type we want to find paths for.
+        found_paths_list (list): The list of paths that will are found.
+
+    Returns:
+        None
+
+    """
+    if scene.object(path).typeName() == object_type_name:
+        found_paths_list.append(path)
+    for childName in scene.childNames(path):
+        find_paths(scene, path.rstrip("/") + "/" + str(childName), object_type_name, found_paths_list)

--- a/openpype/hosts/gaffer/plugins/load/load_camera.py
+++ b/openpype/hosts/gaffer/plugins/load/load_camera.py
@@ -3,7 +3,7 @@ from openpype.pipeline import (
     get_representation_path,
 )
 from openpype.hosts.gaffer.api import get_root, imprint_container
-from openpype.hosts.gaffer.api.lib import set_node_color, arrange, make_box
+from openpype.hosts.gaffer.api.lib import set_node_color, arrange, make_box, find_camera_paths
 
 import Gaffer
 import GafferScene
@@ -40,7 +40,7 @@ class GafferLoadAlembicCamera(load.LoaderPlugin):
 
         path_filter = GafferScene.PathFilter("all")
         box.addChild(path_filter)
-        path_filter["paths"].setValue(IECore.StringVectorData(["*"]))
+
         create_set["filter"].setInput(path_filter["out"])
 
         box["BoxOut"]["in"].setInput(create_set["out"])
@@ -53,6 +53,14 @@ class GafferLoadAlembicCamera(load.LoaderPlugin):
         # Set the filename
         path = self.filepath_from_context(context).replace("\\", "/")
         box["fileName"].setValue(path)
+
+        # find the path to the cameras in the newly read file to base our filter on
+        cameras = find_camera_paths(reader["out"])
+        if len(cameras) > 0:
+            camera_filter = cameras
+        else:
+            camera_filter = ['*']
+        path_filter["paths"].setValue(IECore.StringVectorData(camera_filter))
 
         # Layout the nodes within the box
         arrange(box.children(Gaffer.Node))

--- a/openpype/hosts/gaffer/plugins/load/load_reference.py
+++ b/openpype/hosts/gaffer/plugins/load/load_reference.py
@@ -53,7 +53,7 @@ class GafferLoadReference(load.LoaderPlugin):
         node.load(path)
 
         # Update the imprinted representation
-        node["user"]["representation"].SetValue(str(representation["_id"]))
+        node["user"]["representation"].setValue(str(representation["_id"]))
 
     def remove(self, container):
         node = container["_node"]

--- a/openpype/hosts/gaffer/startup/gui/openpype_menu.py
+++ b/openpype/hosts/gaffer/startup/gui/openpype_menu.py
@@ -64,7 +64,7 @@ def _install_openpype_menu():
 
 def _install_openpype():
     print("Installing OpenPype ...")
-    install_host(GafferHost())
+    install_host(GafferHost(application))
 
 
 _install_openpype()


### PR DESCRIPTION
## Changelog Description

It's useful to have the `$project:rootDirectory` pointing to your working directory - well I think so at least -. And it's nice to have a callback that does that. This included passing `application` to the GafferHost - not sure if there is a nicer way to do that - it's been a while since I did some gaffer dev.

Now when loading a camera it traverses the scene hierarchy of the loaded scene and populates the pathfilter with paths to all the `Camera` objects found.
