### PR TITLE
When creating a box to publish allow using selection.

### DIFF
--- a/openpype/hosts/gaffer/api/lib.py
+++ b/openpype/hosts/gaffer/api/lib.py
@@ -105,6 +105,7 @@ def arrange(nodes: List[Gaffer.Node], parent: Optional[Gaffer.Node] = None):
     graph.getLayout().layoutNodes(graph, Gaffer.StandardSet(nodes))
 
 
+
 def traverse_scene(scene_plug: GafferScene.ScenePlug,
                    root: str = "/") -> Iterator[str]:
     """Yields breadth first all children from given `root`.

--- a/openpype/hosts/gaffer/api/pipeline.py
+++ b/openpype/hosts/gaffer/api/pipeline.py
@@ -150,7 +150,8 @@ class GafferHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def _on_scene_new(self, script_container, script_node):
         # Update the projectRootDirectory variable for new workfile scripts
-        script_node['variables']['projectRootDirectory']['value'].setValue(self.work_root(os.environ))  # noqa
+        script_node['variables']['projectRootDirectory']['value'].setValue(
+            self.work_root(os.environ))  # noqa
 
 
 def imprint_container(node: Gaffer.Node,

--- a/openpype/hosts/gaffer/plugins/create/create_gaffer_nodes.py
+++ b/openpype/hosts/gaffer/plugins/create/create_gaffer_nodes.py
@@ -1,4 +1,4 @@
-from openpype.hosts.gaffer.api.lib import make_box
+from openpype.hosts.gaffer.api.lib import make_box, set_node_color
 from openpype.hosts.gaffer.api import plugin
 
 import Gaffer
@@ -13,5 +13,31 @@ class CreateGafferNodes(plugin.GafferCreatorBase):
 
     def _create_node(self,
                      subset_name: str,
-                     pre_create_data: dict) -> Gaffer.Node:
-        return make_box(subset_name)
+                     pre_create_data: dict,
+                     script: Gaffer.ScriptNode) -> Gaffer.Node:
+
+        if len(self.selected_nodes) > 0:
+            box_nodes = [node for node in self.selected_nodes
+                         if node.typeName() == "Gaffer::Box"]
+
+            if len(box_nodes) == 1 and len(self.selected_nodes) == 1:
+                # we have one and just one box selected. So just mark
+                # that for publish
+                box_node = box_nodes[0]
+                data = self._read(box_node)
+                if data.get("id") == "pyblish.avalon.instance":
+                    raise plugin.GafferCreatorError(
+                        "This box is already being published!")
+            else:
+                # we have a mix of other nodes, group 'em up
+                box_node = Gaffer.Box.create(script, self.selected_nodes)
+                box_node.setName(subset_name)
+        else:
+            box_node = make_box(subset_name)
+            script.addChild(box_node)
+
+        # colorise boxes to be published
+        # TODO: Use settings instead
+        set_node_color(box_node, (0.788, 0.39, 0.22))
+
+        return box_node


### PR DESCRIPTION
## Changelog Description
So if `use selection` is enabled (disabled by default) one of three things happens:
  1. If nothing is selected - raises an error
  2. If one box node is selected - marks that box for publish (unless it already has been, in that case: error)
  3. Takes all selected nodes, and puts them into the box that gets created.

This is perhaps unclear. However having the ability to mark existing boxes as an instance is quite handy for us. 
